### PR TITLE
[deps] remove libc and minimise required chrono features

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,9 +15,7 @@ build = "build.rs"
 links = "static=sgp4"
 
 [dependencies]
-chrono = { version="0.4" }
-time = "0.2.16"
-libc = "0.2.71"
+chrono = { version="0.4", default-features=false }
 thiserror = "1.0"
 
 [build-dependencies]

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -4,8 +4,8 @@
 //! rely heavily on `unsafe` code, and it is recommended to instead use the other, high level
 //! bindings provided by the `sgp4` crate.
 
-use std::os::raw::{c_char, c_double, c_int, c_long};
 use std::ffi::{CString, NulError};
+use std::os::raw::{c_char, c_double, c_int, c_long};
 
 use chrono::prelude::*;
 use chrono::DateTime;

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -4,9 +4,7 @@
 //! rely heavily on `unsafe` code, and it is recommended to instead use the other, high level
 //! bindings provided by the `sgp4` crate.
 
-extern crate libc;
-
-use libc::{c_char, c_double, c_int, c_long};
+use std::os::raw::{c_char, c_double, c_int, c_long};
 use std::ffi::{CString, NulError};
 
 use chrono::prelude::*;


### PR DESCRIPTION
- libc isn't required and we can utilise `std::os::raw` types instead
- minimise required chrono features (we need none of the defaults)