### PR TITLE
Make the StateVector::new constructor public

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -36,7 +36,7 @@ pub struct StateVector {
 }
 
 impl StateVector {
-    fn new(epoch: DateTime<Utc>, position: [f64; 3], velocity: [f64; 3]) -> Self {
+    pub fn new(epoch: DateTime<Utc>, position: [f64; 3], velocity: [f64; 3]) -> Self {
         Self {
             epoch,
             position,


### PR DESCRIPTION
StateVector is normally returned by the SGP4 propagation routine, but it can also be used to extract the Keplerian elements when an object's position and velocity are known at a given epoch. Exposing the constructor allows users to skip SGP4 propagation or to integrate with other propagators when this information is available.
