### PR TITLE
Add get mean motion

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "sgp4-rs"
-version = "0.3.2"
+version = "0.3.3"
 authors = ["Nick Pascucci <nick.pascucci@spire.com>"]
 edition = "2021"
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -302,6 +302,8 @@ impl TwoLineElement {
         Ok(self.elements.epoch())
     }
 
+    pub fn mean_motion(&self) -> f64 {self.elements.mean_motion()}
+
     /// Propagate a TwoLineElement to the given time to obtain a state vector for the object.
     pub fn propagate_to(&self, t: DateTime<Utc>) -> Result<StateVector> {
         let tle_epoch = self.elements.epoch();

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -375,6 +375,8 @@ impl OrbitalElementSet {
     pub fn epoch(&self) -> DateTime<Utc> {
         julian_day_to_datetime(self.julian_date_at_epoch)
     }
+
+    pub fn mean_motion(&self) -> f64 {self.mean_motion as _}
 }
 
 pub(crate) fn julian_day_to_datetime(jd: c_double) -> DateTime<Utc> {


### PR DESCRIPTION
Need to use the mean motion for some checks in the new transit generation. 

Allow can you push the update to crates.io when merged.