### PR TITLE
Pass Errors through SPG4 with tranparency

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -390,7 +390,7 @@ mod tests {
     }
 
     #[test]
-    fn test_decay_error() -> Result<()>{
+    fn test_decay_error() -> Result<()> {
         let line1 = "1 43051U 17071Q   22046.92182028  .07161566  12340-4  74927-3 0  9993";
         let line2 = "2 43051  51.6207 236.5853 0009084 284.2762  75.7254 16.36736354237455";
         let tle = TwoLineElement::new(line1, line2)?;
@@ -398,7 +398,10 @@ mod tests {
 
         let s2 = tle.propagate_to(epoch + Duration::days(30));
         assert!(s2.is_err());
-        assert_eq!(s2.unwrap_err(), Error::PropagationError(sgp4_sys::Error::SatelliteDecay));
+        assert_eq!(
+            s2.unwrap_err(),
+            Error::PropagationError(sgp4_sys::Error::SatelliteDecay)
+        );
         Ok(())
     }
 

--- a/src/sgp4/sgp4unit.cpp
+++ b/src/sgp4/sgp4unit.cpp
@@ -1888,7 +1888,6 @@ bool sgp4(gravconsttype whichconst, elsetrec &satrec, double tsince,
    // fix tolerance for error recognition
   // sgp4fix am is fixed from the previous nm check
   if ((em >= 1.0) || (em < -0.001) /* || (am < 0.95)*/) {
-    //         printf("# error em %f\n", em);
     satrec.error = 1;
     // sgp4fix to return if there is an error in eccentricity
     return false;

--- a/src/sgp4/sgp4unit.cpp
+++ b/src/sgp4/sgp4unit.cpp
@@ -1731,15 +1731,6 @@ bool sgp4(gravconsttype whichconst, elsetrec &satrec, double tsince,
   nm = xke / pow(am, 1.5);
   em = em - tempe;
 
-  // fix tolerance for error recognition
-  // sgp4fix am is fixed from the previous nm check
-  if ((em >= 1.0) || (em < -0.001) /* || (am < 0.95)*/) {
-    //         printf("# error em %f\n", em);
-    satrec.error = 1;
-    // sgp4fix to return if there is an error in eccentricity
-    return false;
-  }
-  // sgp4fix fix tolerance to avoid a divide by zero
   if (em < 1.0e-6)
     em = 1.0e-6;
   mm = mm + satrec.no * templ;
@@ -1893,6 +1884,16 @@ bool sgp4(gravconsttype whichconst, elsetrec &satrec, double tsince,
     satrec.error = 6;
     return false;
   }
+
+   // fix tolerance for error recognition
+  // sgp4fix am is fixed from the previous nm check
+  if ((em >= 1.0) || (em < -0.001) /* || (am < 0.95)*/) {
+    //         printf("# error em %f\n", em);
+    satrec.error = 1;
+    // sgp4fix to return if there is an error in eccentricity
+    return false;
+  }
+  // sgp4fix fix tolerance to avoid a divide by zero
 
   //#include "debug7.cpp"
   return true;

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -476,7 +476,7 @@ pub(crate) fn to_orbital_elements(
         )
     };
 
-    satrec.error_match()
+    satrec.into_validated_result()
 }
 
 type Vec3 = [c_double; 3];
@@ -503,7 +503,7 @@ pub(crate) fn run_sgp4(
     };
 
     if !success {
-        match satrec_copy.error_match() {
+        match satrec_copy.into_validated_result() {
             Ok(_) => unreachable!("SGP4 failure but didn't return an error"),
             Err(e) => Err(e),
         }

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -390,7 +390,7 @@ impl OrbitalElementSet {
         self.mean_motion as _
     }
 
-    pub(crate) fn error_match(self) -> Result<OrbitalElementSet, Error> {
+    pub(crate) fn into_validated_result(self) -> Result<OrbitalElementSet, Error> {
         match self.error {
             0 => Ok(self),
             1 => Err(Error::InvalidEccentricity),

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -22,7 +22,7 @@ pub enum Error {
     InvalidEccentricity,
     #[error("Mean motion must be positive")]
     NegativeMeanMotion,
-    #[error(" Eccentricity out of bounds for pert elements")]
+    #[error("Eccentricity out of bounds for pert elements")]
     PertEccentricity,
     #[error("Semi-latus rectum must be positive")]
     NegativeSemiLatus,

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -12,14 +12,24 @@ use chrono::DateTime;
 
 use thiserror::Error;
 
-#[derive(Debug, Error)]
-pub(crate) enum Error {
+#[derive(Debug, Error, PartialEq)]
+pub enum Error {
     #[error(transparent)]
     CStringNul(#[from] NulError),
-    #[error("Failed to convert two-line element to orbital element set: {0}")]
-    TwoLine2Rv(&'static str),
-    #[error("Failure in SGP4 propagator")]
-    Sgp4,
+    #[error("Unknown Failure in SGP4 propagator")]
+    Unknown,
+    #[error("Eccentricity out of bounds for mean elements")]
+    InvalidEccentricity,
+    #[error("Mean motion must be positive")]
+    NegativeMeanMotion,
+    #[error(" Eccentricity out of bounds for pert elements")]
+    PertEccentricity,
+    #[error("Semi-latus rectum must be positive")]
+    NegativeSemiLatus,
+    #[error("Epoch elements are sub-orbital")]
+    SubOrbital,
+    #[error("Satellite has decayed")]
+    SatelliteDecay,
 }
 
 #[allow(dead_code)]
@@ -379,6 +389,19 @@ impl OrbitalElementSet {
     pub(crate) fn mean_motion(&self) -> f64 {
         self.mean_motion as _
     }
+
+    pub(crate) fn error_match(self) -> Result<OrbitalElementSet, Error> {
+        match self.error {
+            0 => Ok(self),
+            1 => Err(Error::InvalidEccentricity),
+            2 => Err(Error::NegativeMeanMotion),
+            3 => Err(Error::PertEccentricity),
+            4 => Err(Error::NegativeSemiLatus),
+            5 => Err(Error::SubOrbital),
+            6 => Err(Error::SatelliteDecay),
+            _ => Err(Error::Unknown),
+        }
+    }
 }
 
 pub(crate) fn julian_day_to_datetime(jd: c_double) -> DateTime<Utc> {
@@ -453,21 +476,7 @@ pub(crate) fn to_orbital_elements(
         )
     };
 
-    match satrec.error {
-        0 => Ok(satrec),
-        // TODO Expand this match to include specific error conditions
-        1 => Err(Error::TwoLine2Rv(
-            "Eccentricity out of bounds for mean elements",
-        )),
-        2 => Err(Error::TwoLine2Rv("Mean motion must be positive")),
-        3 => Err(Error::TwoLine2Rv(
-            "Eccentricity out of bounds for pert elements",
-        )),
-        4 => Err(Error::TwoLine2Rv("Semi-latus rectum must be positive")),
-        5 => Err(Error::TwoLine2Rv("Epoch elements are sub-orbital")),
-        6 => Err(Error::TwoLine2Rv("Satellite has decayed")),
-        _ => Err(Error::TwoLine2Rv("Unknown error code")),
-    }
+    satrec.error_match()
 }
 
 type Vec3 = [c_double; 3];
@@ -494,7 +503,10 @@ pub(crate) fn run_sgp4(
     };
 
     if !success {
-        Err(Error::Sgp4)
+        match satrec_copy.error_match() {
+            Ok(_) => unreachable!("SGP4 failure but didn't return an error"),
+            Err(e) => Err(e),
+        }
     } else {
         Ok((ro, vo))
     }
@@ -807,8 +819,74 @@ mod tests {
                 vo.as_mut_ptr(),
             );
         }
+        assert_eq!(satrec_copy.error, 0);
+    }
+
+    #[test]
+    fn test_errors() {
+        //This TLE decays on by the end Feb 2022
+        // 0 LEMUR 2 MCCULLAGH
+        //1 43051U 17071Q   22046.92182028  .07161566  12340-4  74927-3 0  9993
+        //2 43051  51.6207 236.5853 0009084 284.2762  75.7254 16.36736354237455
+        let longstr1 =
+            CString::new("1 43051U 17071Q   22046.92182028  .07161566  12340-4  74927-3 0  9993")
+                .unwrap();
+        let longstr2 =
+            CString::new("2 43051  51.6207 236.5853 0009084 284.2762  75.7254 16.36736354237455")
+                .unwrap();
+        let typerun = 'v' as c_char;
+        let typeinput = 'v' as c_char;
+        let opsmode = 'a' as c_char;
+        let whichconst = GravitationalConstant::Wgs72;
+        let mut startmfe: c_double = 0.;
+        let mut stopmfe: c_double = 0.;
+        let mut deltamin: c_double = 0.;
+        let mut satrec: OrbitalElementSet = OrbitalElementSet::default();
+        let mut ro: [c_double; 3] = [0.; 3];
+        let mut vo: [c_double; 3] = [0.; 3];
+
+        unsafe {
+            twoline2rv(
+                longstr1.as_ptr(),
+                longstr2.as_ptr(),
+                typerun,
+                typeinput,
+                opsmode,
+                whichconst,
+                &mut startmfe,
+                &mut stopmfe,
+                &mut deltamin,
+                &mut satrec,
+            );
+        }
+
+        let satrec = satrec;
+        let mut satrec_copy = satrec.to_owned();
+
+        unsafe {
+            sgp4(
+                whichconst,
+                &mut satrec_copy,
+                0.0,
+                ro.as_mut_ptr(),
+                vo.as_mut_ptr(),
+            );
+        }
 
         assert_eq!(satrec_copy.error, 0);
+
+        // Propagate out 60 minutes.
+        let mut satrec_copy = satrec.to_owned();
+            unsafe {
+                sgp4(
+                    whichconst,
+                    &mut satrec_copy,
+                    10000.,
+                    ro.as_mut_ptr(),
+                    vo.as_mut_ptr(),
+                );
+            }
+            assert_eq!(satrec_copy.error, 6)
     }
 
     #[test]

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -16,7 +16,7 @@ use thiserror::Error;
 pub enum Error {
     #[error(transparent)]
     CStringNul(#[from] NulError),
-    #[error("Unknown Failure in SGP4 propagator")]
+    #[error("Unknown failure in SGP4 propagator")]
     Unknown,
     #[error("Eccentricity out of bounds for mean elements")]
     InvalidEccentricity,

--- a/src/sgp4_sys.rs
+++ b/src/sgp4_sys.rs
@@ -877,16 +877,16 @@ mod tests {
 
         // Propagate out 60 minutes.
         let mut satrec_copy = satrec.to_owned();
-            unsafe {
-                sgp4(
-                    whichconst,
-                    &mut satrec_copy,
-                    10000.,
-                    ro.as_mut_ptr(),
-                    vo.as_mut_ptr(),
-                );
-            }
-            assert_eq!(satrec_copy.error, 6)
+        unsafe {
+            sgp4(
+                whichconst,
+                &mut satrec_copy,
+                10000.,
+                ro.as_mut_ptr(),
+                vo.as_mut_ptr(),
+            );
+        }
+        assert_eq!(satrec_copy.error, 6)
     }
 
     #[test]


### PR DESCRIPTION
The C++ code has a set of define errors that we can pass through and match.

```
*  return code - non-zero on error.
*                   1 - mean elements, ecc >= 1.0 or ecc < -0.001 or a < 0.95 er
*                   2 - mean motion less than 0.0
*                   3 - pert elements, ecc < 0.0  or  ecc > 1.0
*                   4 - semi-latus rectum < 0.0
*                   5 - epoch elements are sub-orbital
*                   6 - satellite has decayed
```

It does have an interesting quirk that satellites decaying fail by error code 1 first. Moving this error code after error code 6 seems to have fixed the issue and return the correct codes. 